### PR TITLE
Drop frames when the Lighthouse cannot keep up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ dotenvy = "0.15.7"
 futures = "0.3.30"
 lighthouse-client = "3.2.0"
 socket2 = "0.5.6"
-tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros", "sync"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use artnet_protocol::ArtCommand;
 use lighthouse_client::{protocol::LIGHTHOUSE_BYTES, Lighthouse, TokioWebSocket};
 use tokio::{net::UdpSocket, sync::mpsc};
-use tracing::{info, info_span, warn, Instrument};
+use tracing::{debug, info, info_span, warn, Instrument};
 
 use crate::{address::DmxAddress, allocation::DmxAllocation};
 
@@ -58,7 +58,7 @@ impl ArtNetAdapter {
         match command {
             ArtCommand::Output(output) => {
                 let universe = u16::from(output.port_address) as usize;
-                info! {
+                debug! {
                     version = ?output.version,
                     sequence = output.sequence,
                     universe = universe,

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -30,7 +30,11 @@ impl ArtNetAdapter {
     }
 
     pub async fn run(mut self) -> Result<()> {
-        // TODO: Factor out Lighthouse forwarder into separate structure?
+        self.spawn_lighthouse_forwarder();
+        self.run_artnet_listener().await
+    }
+
+    fn spawn_lighthouse_forwarder(&mut self) {
         let mut lh = self.lh.take().unwrap();
         let frame = self.frame.clone();
         let frame_count = self.frame_count.clone();
@@ -55,7 +59,9 @@ impl ArtNetAdapter {
                 }
             }
         });
+    }
 
+    async fn run_artnet_listener(mut self) -> Result<()> {
         info!("Listening for Art-Net packets on {} (UDP)", self.socket.local_addr()?);
         loop {
             let mut buffer = [0u8; 1024];


### PR DESCRIPTION
The Lighthouse WebSocket connection is frequently too slow to keep up with fast animations, i.e. we run into the classic backpressure problem (fast producer, slow consumer).

To address this issue, we move the Lighthouse forwarding mechanism to a separate Tokio task and emit frames via a bounded queue of size 1 as Art-Net commands are received, dropping any frames if the queue is full. Effectively this causes us to drop any frames while the forwarding task waits for the Lighthouse to send a response.

This works well if the producer keeps sending frames quickly but may suffer from dropping the "final" frame once the animation stops. Ideally we would have a ring-buffer-like queue that automatically "forces" the consumer to skip values at the front when it cannot handle them, though I am not sure whether Tokio offers something like this natively.

Additionally we might want to factor out the Lighthouse forwarding mechanism from the Art-Net receiver, which are now more decoupled thanks to the queue mechanism. See also the todo comment on this.